### PR TITLE
fmt should print float number instead of integers

### DIFF
--- a/deployment.go
+++ b/deployment.go
@@ -107,15 +107,15 @@ func mutateDeploymentResources(ar v1beta1.AdmissionReview) *v1beta1.AdmissionRes
 		totalCPUMili += container.Resources.Requests.Cpu().MilliValue()
 		totalMEMMb += container.Resources.Requests.Memory().Value()
 	}
-	klog.V(4).Infof("total milicore for pod %d ", totalCPUMili)
-	klog.V(4).Infof("total MB for pod - %d", totalMEMMb)
+	klog.V(4).Infof("total milicore for pod %f ", totalCPUMili)
+	klog.V(4).Infof("total MB for pod - %f", totalMEMMb)
 
 	// calc ratio for all containers
 	contRatio := make(map[string]*containerResourceRatio)
 	for _, container := range modifiedDeploy.Spec.Template.Spec.Containers {
 		cpuRatio := float64(container.Resources.Requests.Cpu().MilliValue()) / float64(totalCPUMili)
 		memRatio := float64(container.Resources.Requests.Memory().Value()) / float64(totalMEMMb)
-		klog.V(4).Infof("cpuRatio = %d , memRatio = %d", cpuRatio, memRatio)
+		klog.V(4).Infof("cpuRatio = %f , memRatio = %f", cpuRatio, memRatio)
 		contRatio[container.Name] = &containerResourceRatio{
 			CPURatio: cpuRatio,
 			MEMRatio: memRatio,
@@ -269,8 +269,8 @@ func oceanResourceSuggestions(context context.Context, svc *ocean.ServiceOp, oce
 					corev1.ResourceMemory: parseResourceMemory(suggestion.SuggestedMemory),
 				}, nil
 			}
-			klog.V(4).Infof("suggested cpu is %d", *suggestion.SuggestedCPU)
-			klog.V(4).Infof("suggested mem is %d", *suggestion.SuggestedMemory)
+			klog.V(4).Infof("suggested cpu is %f", *suggestion.SuggestedCPU)
+			klog.V(4).Infof("suggested mem is %f", *suggestion.SuggestedMemory)
 
 			return &corev1.ResourceList{
 				corev1.ResourceCPU:    parseResourceCPU(suggestion.SuggestedCPU),


### PR DESCRIPTION
In the klog of the webhook server, there has been some float numbers printed as integers which might cause confusions, so better with %v or %f:


```
/*
ResourceSuggestion represents a single resource suggestion.
https://github.com/spotinst/spotinst-sdk-go/blob/f4ac60e9cf6aed86ad55adaf29f25fd57bc1b6bc/service/ocean/providers/aws/rightsizing.go#L15
*/
type ResourceSuggestion struct {
	ResourceName    *string                        `json:"resourceName,omitempty"`
	ResourceType    *string                        `json:"resourceType,omitempty"`
	DeploymentName  *string                        `json:"deploymentName,omitempty"`
	Namespace       *string                        `json:"namespace,omitempty"`
	SuggestedCPU    *float64                       `json:"suggestedCPU,omitempty"`
	RequestedCPU    *float64                       `json:"requestedCPU,omitempty"`
	SuggestedMemory *float64                       `json:"suggestedMemory,omitempty"`
	RequestedMemory *float64                       `json:"requestedMemory,omitempty"`
	Containers      []*ContainerResourceSuggestion `json:"containers,omitempty"`
}
```

Example log:
```
I0612 02:27:43.044832       1 deployment.go:272] suggested cpu is %!d(float64=1000)
I0612 02:27:43.044850       1 deployment.go:273] suggested mem is %!d(float64=4)
I0612 02:27:43.044883       1 deployment.go:110] total milicore for pod 500 
I0612 02:27:43.044909       1 deployment.go:111] total MB for pod - 1073741824
I0612 02:27:43.044929       1 deployment.go:118] cpuRatio = %!d(float64=1) , memRatio = %!d(float64=1)
```

Example code:

```
klog.V(4).Infof("total milicore for pod %d ", totalCPUMili) <br>
klog.V(4).Infof("total MB for pod - %d", totalMEMMb)
```