### PR TITLE
admissionReview version v1 must have a well-formed v1 AdmissionReview object

### DIFF
--- a/deployment.go
+++ b/deployment.go
@@ -107,15 +107,15 @@ func mutateDeploymentResources(ar v1beta1.AdmissionReview) *v1beta1.AdmissionRes
 		totalCPUMili += container.Resources.Requests.Cpu().MilliValue()
 		totalMEMMb += container.Resources.Requests.Memory().Value()
 	}
-	klog.V(4).Infof("total milicore for pod %f ", totalCPUMili)
-	klog.V(4).Infof("total MB for pod - %f", totalMEMMb)
+	klog.V(4).Infof("total milicore for pod %d ", totalCPUMili)
+	klog.V(4).Infof("total MB for pod - %d", totalMEMMb)
 
 	// calc ratio for all containers
 	contRatio := make(map[string]*containerResourceRatio)
 	for _, container := range modifiedDeploy.Spec.Template.Spec.Containers {
 		cpuRatio := float64(container.Resources.Requests.Cpu().MilliValue()) / float64(totalCPUMili)
 		memRatio := float64(container.Resources.Requests.Memory().Value()) / float64(totalMEMMb)
-		klog.V(4).Infof("cpuRatio = %f , memRatio = %f", cpuRatio, memRatio)
+		klog.V(4).Infof("cpuRatio = %d , memRatio = %d", cpuRatio, memRatio)
 		contRatio[container.Name] = &containerResourceRatio{
 			CPURatio: cpuRatio,
 			MEMRatio: memRatio,

--- a/deployment.go
+++ b/deployment.go
@@ -214,7 +214,10 @@ func mutateDeploymentResources(ar v1beta1.AdmissionReview) *v1beta1.AdmissionRes
 	// }
 
 	reviewResponse.Allowed = allowResponse
+        out, _ := json.Marshal(reviewResponse)
+        klog.V(4).Infof("reviewResponse= %v", string(out))
 	return &reviewResponse
+
 }
 
 func resourceSuggestions(deployment, namespace string) (*corev1.ResourceList, error) {

--- a/deployment.go
+++ b/deployment.go
@@ -214,8 +214,6 @@ func mutateDeploymentResources(ar v1beta1.AdmissionReview) *v1beta1.AdmissionRes
 	// }
 
 	reviewResponse.Allowed = allowResponse
-        out, _ := json.Marshal(reviewResponse)
-        klog.V(4).Infof("reviewResponse= %v", string(out))
 	return &reviewResponse
 
 }

--- a/deployment.go
+++ b/deployment.go
@@ -272,8 +272,8 @@ func oceanResourceSuggestions(context context.Context, svc *ocean.ServiceOp, oce
 					corev1.ResourceMemory: parseResourceMemory(suggestion.SuggestedMemory),
 				}, nil
 			}
-			klog.V(4).Infof("suggested cpu is %f", *suggestion.SuggestedCPU)
-			klog.V(4).Infof("suggested mem is %f", *suggestion.SuggestedMemory)
+			klog.V(4).Infof("suggested cpu is %d", *suggestion.SuggestedCPU)
+			klog.V(4).Infof("suggested mem is %d", *suggestion.SuggestedMemory)
 
 			return &corev1.ResourceList{
 				corev1.ResourceCPU:    parseResourceCPU(suggestion.SuggestedCPU),

--- a/deployment.go
+++ b/deployment.go
@@ -215,7 +215,6 @@ func mutateDeploymentResources(ar v1beta1.AdmissionReview) *v1beta1.AdmissionRes
 
 	reviewResponse.Allowed = allowResponse
 	return &reviewResponse
-
 }
 
 func resourceSuggestions(deployment, namespace string) (*corev1.ResourceList, error) {

--- a/deployment.go
+++ b/deployment.go
@@ -107,15 +107,15 @@ func mutateDeploymentResources(ar v1beta1.AdmissionReview) *v1beta1.AdmissionRes
 		totalCPUMili += container.Resources.Requests.Cpu().MilliValue()
 		totalMEMMb += container.Resources.Requests.Memory().Value()
 	}
-	klog.V(4).Infof("total milicore for pod %d ", totalCPUMili)
-	klog.V(4).Infof("total MB for pod - %d", totalMEMMb)
+	klog.V(4).Infof("total milicore for pod %f ", totalCPUMili)
+	klog.V(4).Infof("total MB for pod - %f", totalMEMMb)
 
 	// calc ratio for all containers
 	contRatio := make(map[string]*containerResourceRatio)
 	for _, container := range modifiedDeploy.Spec.Template.Spec.Containers {
 		cpuRatio := float64(container.Resources.Requests.Cpu().MilliValue()) / float64(totalCPUMili)
 		memRatio := float64(container.Resources.Requests.Memory().Value()) / float64(totalMEMMb)
-		klog.V(4).Infof("cpuRatio = %d , memRatio = %d", cpuRatio, memRatio)
+		klog.V(4).Infof("cpuRatio = %f , memRatio = %f", cpuRatio, memRatio)
 		contRatio[container.Name] = &containerResourceRatio{
 			CPURatio: cpuRatio,
 			MEMRatio: memRatio,
@@ -269,8 +269,8 @@ func oceanResourceSuggestions(context context.Context, svc *ocean.ServiceOp, oce
 					corev1.ResourceMemory: parseResourceMemory(suggestion.SuggestedMemory),
 				}, nil
 			}
-			klog.V(4).Infof("suggested cpu is %d", *suggestion.SuggestedCPU)
-			klog.V(4).Infof("suggested mem is %d", *suggestion.SuggestedMemory)
+			klog.V(4).Infof("suggested cpu is %f", *suggestion.SuggestedCPU)
+			klog.V(4).Infof("suggested mem is %f", *suggestion.SuggestedMemory)
 
 			return &corev1.ResourceList{
 				corev1.ResourceCPU:    parseResourceCPU(suggestion.SuggestedCPU),

--- a/main.go
+++ b/main.go
@@ -63,11 +63,14 @@ func serve(w http.ResponseWriter, r *http.Request, admit admitFunc) {
 
 	// Return the same UID
 	responseAdmissionReview.Response.UID = requestedAdmissionReview.Request.UID
+        
+        // Add APIVersion and Kind
         responseAdmissionReview.TypeMeta = metav1.TypeMeta{
 			APIVersion: "admission.k8s.io/v1",
 			Kind:       "AdmissionReview",
 		}
 	respBytes, err := json.Marshal(responseAdmissionReview)
+        
         //klog.V(4).Infof("AdmissionReview Response = %s", string(respBytes))
 
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -63,8 +63,15 @@ func serve(w http.ResponseWriter, r *http.Request, admit admitFunc) {
 
 	// Return the same UID
 	responseAdmissionReview.Response.UID = requestedAdmissionReview.Request.UID
-
+        //responseAdmissionReview.Response.apiVersion = "admission.k8s.io/v1"
+        //responseAdmissionReview.Response.kind = "AdmissionReview"
+        responseAdmissionReview.TypeMeta = metav1.TypeMeta{
+			APIVersion: "admission.k8s.io/v1",
+			Kind:       "AdmissionReview",
+		}
 	respBytes, err := json.Marshal(responseAdmissionReview)
+        klog.V(4).Infof("AdmissionReview Response = %s", string(respBytes))
+
 	if err != nil {
 		klog.Error(err)
 	}

--- a/main.go
+++ b/main.go
@@ -63,14 +63,12 @@ func serve(w http.ResponseWriter, r *http.Request, admit admitFunc) {
 
 	// Return the same UID
 	responseAdmissionReview.Response.UID = requestedAdmissionReview.Request.UID
-        //responseAdmissionReview.Response.apiVersion = "admission.k8s.io/v1"
-        //responseAdmissionReview.Response.kind = "AdmissionReview"
         responseAdmissionReview.TypeMeta = metav1.TypeMeta{
 			APIVersion: "admission.k8s.io/v1",
 			Kind:       "AdmissionReview",
 		}
 	respBytes, err := json.Marshal(responseAdmissionReview)
-        klog.V(4).Infof("AdmissionReview Response = %s", string(respBytes))
+        //klog.V(4).Infof("AdmissionReview Response = %s", string(respBytes))
 
 	if err != nil {
 		klog.Error(err)


### PR DESCRIPTION
when testing it on EKS with Kubernetes 1.21.12,  I got the below error when specifying v1, and v1beta supported version in mutatingwebhookconfiguration.

`admissionReviewVersions: ["v1","v1beta1"]`
<img width="467" alt="image" src="https://user-images.githubusercontent.com/11757216/173240067-c022ac64-0ab8-4c39-ac85-42e807168512.png">

https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#response

And json patch was not successful, since v1 says it must return a well-formed object with "APIVersion" and "Kind".

```
ka ../httpd.yaml
Error from server (InternalError): error when applying patch:
{"metadata":{"annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"metadata\":{\"annotations\":{},\"labels\":{\"spot.io/mutate-resource\":\"enabled\"},\"name\":\"my-httpd\",\"namespace\":\"default\"},\"spec\":{\"replicas\":2,\"selector\":{\"matchLabels\":{\"run\":\"my-httpd\"}},\"template\":{\"metadata\":{\"labels\":{\"run\":\"my-httpd\"}},\"spec\":{\"containers\":[{\"image\":\"httpd\",\"name\":\"my-httpd\",\"ports\":[{\"containerPort\":90}],\"resources\":{\"limits\":{\"cpu\":\"1500m\",\"memory\":\"2048Mi\"},\"requests\":{\"cpu\":\"500m\",\"memory\":\"512Mi\"}}}]}}}}\n"}},"spec":{"template":{"spec":{"$setElementOrder/containers":[{"name":"my-httpd"}],"containers":[{"$setElementOrder/ports":[{"containerPort":90}],"name":"my-httpd","ports":[{"containerPort":90},{"$patch":"delete","containerPort":8080}],"resources":{"limits":{"memory":"2048Mi"}}}]}}}}
to:
Resource: "apps/v1, Resource=deployments", GroupVersionKind: "apps/v1, Kind=Deployment"
Name: "my-httpd", Namespace: "default"
**for: "../httpd.yaml": Internal error occurred: failed calling webhook "ocean-rs-mutator.cluster.local": expected webhook response of admission.k8s.io/v1, Kind=AdmissionReview, got /, Kind=**
```
After adding the header and it fixed the issue, please help confirm also.

Thanks.
